### PR TITLE
Deploy version 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@hyperlane-xyz/helloworld",
   "description": "A basic skeleton of an Hyperlane app",
-  "version": "1.0.1-beta0",
+  "version": "1.1.0",
   "dependencies": {
-    "@hyperlane-xyz/sdk": "^1.0.1-beta0",
+    "@hyperlane-xyz/sdk": "^1.1.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.0",
     "ethers": "^5.7.2"
   },
@@ -65,6 +65,5 @@
     "lodash": "^4.17.21",
     "async": "^2.6.4",
     "undici": "^5.11"
-  },
-  "stableVersion": "1.0.0"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,14 +1359,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/core@npm:1.0.1-beta0":
-  version: 1.0.1-beta0
-  resolution: "@hyperlane-xyz/core@npm:1.0.1-beta0"
+"@hyperlane-xyz/core@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@hyperlane-xyz/core@npm:1.1.0"
   dependencies:
-    "@hyperlane-xyz/utils": 1.0.1-beta0
+    "@hyperlane-xyz/utils": 1.1.0
     "@openzeppelin/contracts": ^4.8.0
     "@openzeppelin/contracts-upgradeable": ^4.8.0
-  checksum: c2940686c462a2780f84f27d3e34c7788b542ac4792c36e2f88d433dd6f6dc2830da9ac5c6f07bf99969e09b815a9b562d235895cd7ccd42fa4e02dcaa00b76a
+  checksum: 39f0d0d253a14aec27e187f0e23b9875878eea6a6057421cd04932aa1951a881e5f4ad6953bb128e6d0786480c1b96155bb227cf7499bb89dc75c0483b74e14a
   languageName: node
   linkType: hard
 
@@ -1374,7 +1374,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hyperlane-xyz/helloworld@workspace:."
   dependencies:
-    "@hyperlane-xyz/sdk": ^1.0.1-beta0
+    "@hyperlane-xyz/sdk": ^1.1.0
     "@nomiclabs/hardhat-ethers": ^2.2.1
     "@nomiclabs/hardhat-waffle": ^2.0.3
     "@openzeppelin/contracts-upgradeable": ^4.8.0
@@ -1402,28 +1402,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/sdk@npm:^1.0.1-beta0":
-  version: 1.0.1-beta0
-  resolution: "@hyperlane-xyz/sdk@npm:1.0.1-beta0"
+"@hyperlane-xyz/sdk@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@hyperlane-xyz/sdk@npm:1.1.0"
   dependencies:
     "@hyperlane-xyz/celo-ethers-provider": ^0.1.1
-    "@hyperlane-xyz/core": 1.0.1-beta0
-    "@hyperlane-xyz/utils": 1.0.1-beta0
+    "@hyperlane-xyz/core": 1.1.0
+    "@hyperlane-xyz/utils": 1.1.0
     "@wagmi/chains": ^0.1.3
     coingecko-api: ^1.0.10
     cross-fetch: ^3.1.5
     debug: ^4.3.4
     ethers: ^5.7.2
-  checksum: aa85ced1fc4f0ab57d0373ce3c8a59a175573064f50cb20a4d6b7fe61a070c381e222c735a8872880d760bd960be24644acadf579e7adee3c00a19ba3fb56946
+  checksum: 413fb31f0811f1c0b4b6f881619fbd76a866076889b733929c92bd8add5b03b915fbe54150af3467da7350924f15462688b1c1247937139b11f3ebc3d5e10182
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/utils@npm:1.0.1-beta0":
-  version: 1.0.1-beta0
-  resolution: "@hyperlane-xyz/utils@npm:1.0.1-beta0"
+"@hyperlane-xyz/utils@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@hyperlane-xyz/utils@npm:1.1.0"
   dependencies:
     ethers: ^5.7.2
-  checksum: a87ac6cd90673bbfd5b17dbb68f8fb7626ad16af63315e1080817a87d6c8dfa58d10c69720a5840bf5926942072fa1b9b696ffd4325c007a30bef46cd048402b
+  checksum: e2647b2e04b865f6de557225fca509d4a3a009ddba5ec0c5f44baedaf57be16c42f4d36ffd69acacb1dedc3f4babb5a362d2bce5ddc12b308963add0e415b8c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Unsure what happened with `stableVersion`, looks like it was auto-removed when I released 1.1.0. @jmrossy @yorhodes should I keep it?